### PR TITLE
Add comprehensive CI/CD pipeline for auth and board services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,137 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop, feature/**]
+  pull_request:
+
+jobs:
+  test-all-services:
+    runs-on: ubuntu-latest
+
+    services:
+      # Auth service database
+      auth-postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: test_authdb
+          POSTGRES_USER: kanban_user
+          POSTGRES_PASSWORD: kanban_pass
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      # Board service database  
+      board-postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: test_boarddb
+          POSTGRES_USER: kanban_user
+          POSTGRES_PASSWORD: kanban_pass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Auth service environment
+      AUTH_DATABASE_URL: postgresql+asyncpg://kanban_user:kanban_pass@localhost:5433/test_authdb
+      AUTH_DATABASE_URL_SYNC: postgresql://kanban_user:kanban_pass@localhost:5433/test_authdb
+      SECRET_KEY: supersecretfortests
+      ALGORITHM: HS256
+      ACCESS_TOKEN_EXPIRE_MINUTES: 30
+      REFRESH_TOKEN_EXPIRE_MINUTES: 10080
+      GUEST_EMAIL: guest@example.com
+      GUEST_PASSWORD: guest123
+      
+      # Board service environment
+      DATABASE_URL: postgresql://kanban_user:kanban_pass@localhost:5432/test_boarddb
+      JWT_SECRET: supersecretfortests
+      AUTH_SERVICE_URL: http://localhost:8000
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      # Set up auth service first
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install auth service dependencies
+        run: |
+          cd services/auth
+          poetry install
+
+      - name: Run auth database migrations
+        run: |
+          cd services/auth
+          export DATABASE_URL=$AUTH_DATABASE_URL
+          export DATABASE_URL_SYNC=$AUTH_DATABASE_URL_SYNC
+          export TEST_DATABASE_URL=$AUTH_DATABASE_URL
+          poetry run alembic upgrade head
+
+      - name: Run Auth Service tests
+        run: |
+          cd services/auth
+          export DATABASE_URL=$AUTH_DATABASE_URL
+          export DATABASE_URL_SYNC=$AUTH_DATABASE_URL_SYNC
+          export TEST_DATABASE_URL=$AUTH_DATABASE_URL
+          poetry run pytest tests/ -v
+
+      - name: Start auth service in background
+        run: |
+          cd services/auth
+          export DATABASE_URL=$AUTH_DATABASE_URL
+          export DATABASE_URL_SYNC=$AUTH_DATABASE_URL_SYNC
+          export TEST_DATABASE_URL=$AUTH_DATABASE_URL
+          poetry run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+          sleep 10
+          
+      - name: Seed auth service with guest user
+        run: |
+          cd services/auth
+          export DATABASE_URL=$AUTH_DATABASE_URL
+          export DATABASE_URL_SYNC=$AUTH_DATABASE_URL_SYNC
+          export TEST_DATABASE_URL=$AUTH_DATABASE_URL
+          poetry run python -m app.seeds
+
+      - name: Wait for auth service to be ready
+        run: |
+          echo "Checking if auth service is running..."
+          timeout 30 bash -c 'until curl -f http://localhost:8000/api/v1/health 2>/dev/null; do 
+            echo "Waiting for auth service..."; 
+            sleep 2; 
+          done'
+          echo "Auth service is ready!"
+
+      # Now set up and run board tests
+      - name: Install board service dependencies
+        run: |
+          cd services/board
+          npm install
+
+      - name: Run board database migrations
+        run: |
+          cd services/board
+          npx prisma migrate deploy
+
+      - name: Run board tests
+        run: |
+          cd services/board
+          npm test -- --runInBand

--- a/services/board/tests/board.test.ts
+++ b/services/board/tests/board.test.ts
@@ -3,6 +3,7 @@ import app from '../src/index';
 import prisma from '../src/prisma';
 
 let accessToken: string;
+const authServiceUrl = process.env.AUTH_SERVICE_URL || 'http://auth:8000';
 
 beforeAll(() => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -21,12 +22,12 @@ beforeAll(async () => {
   const email = `testuser${Date.now()}@boardtests.com`;
   const password = 'testpassword';
 
-  await request('http://auth:8000')
+  await request(authServiceUrl)
     .post('/api/v1/users/')
     .send({ email, password });
 
   // Login to get JWT
-  const loginRes = await request('http://auth:8000')
+  const loginRes = await request(authServiceUrl)
     .post('/api/v1/token')
     .type('form')
     .send({ username: email, password });
@@ -111,8 +112,8 @@ describe('Board API', () => {
     // Register and login as a second user
     const email = `otheruser${Date.now()}@boardtests.com`;
     const password = 'testpassword';
-    await request('http://auth:8000').post('/api/v1/users/').send({ email, password });
-    const loginRes = await request('http://auth:8000')
+    await request(authServiceUrl).post('/api/v1/users/').send({ email, password });
+    const loginRes = await request(authServiceUrl)
       .post('/api/v1/token')
       .type('form')
       .send({ username: email, password });

--- a/services/board/tests/column.test.ts
+++ b/services/board/tests/column.test.ts
@@ -3,6 +3,7 @@ import app from '../src/index';
 import prisma from '../src/prisma';
 
 let accessToken: string;
+const authServiceUrl = process.env.AUTH_SERVICE_URL || 'http://auth:8000';
 
 // Suppress console.error during tests
 beforeAll(() => {
@@ -19,12 +20,12 @@ beforeAll(async () => {
   const email = `testuser${Date.now()}@boardtests.com`;
   const password = 'testpassword';
 
-  await request('http://auth:8000')
+  await request(authServiceUrl)
     .post('/api/v1/users/')
     .send({ email, password });
 
   // Login to get JWT
-  const loginRes = await request('http://auth:8000')
+  const loginRes = await request(authServiceUrl)
     .post('/api/v1/token')
     .type('form')
     .send({ username: email, password });

--- a/services/board/tests/rbac.test.ts
+++ b/services/board/tests/rbac.test.ts
@@ -2,6 +2,8 @@ import request from 'supertest';
 import app from '../src/index';
 import prisma from '../src/prisma';
 
+const authServiceUrl = process.env.AUTH_SERVICE_URL || 'http://auth:8000';
+
 let ownerToken: string;
 let editorToken: string;
 let viewerToken: string;
@@ -30,11 +32,11 @@ beforeAll(async () => {
     { email: `addedmember${Date.now()}@boardtests.com`, password: 'pw' },
   ];
   for (const user of users) {
-    await request('http://auth:8000').post('/api/v1/users/').send(user);
+    await request(authServiceUrl).post('/api/v1/users/').send(user);
   }
   // Login and get tokens
   const login = async (email: string, password: string) => {
-    const res = await request('http://auth:8000').post('/api/v1/token').type('form').send({ username: email, password });
+    const res = await request(authServiceUrl).post('/api/v1/token').type('form').send({ username: email, password });
     return res.body.access_token;
   };
 
@@ -47,7 +49,7 @@ beforeAll(async () => {
 
   // Fetch user IDs
   const getUserId = async (token: string) => {
-    const res = await request('http://auth:8000')
+    const res = await request(authServiceUrl)
       .get('/api/v1/me')
       .set('Authorization', `Bearer ${token}`);
     return res.body.id;

--- a/services/board/tests/task.test.ts
+++ b/services/board/tests/task.test.ts
@@ -3,6 +3,7 @@ import app from '../src/index';
 import prisma from '../src/prisma';
 
 let accessToken: string;
+const authServiceUrl = process.env.AUTH_SERVICE_URL || 'http://auth:8000';
 
 // Suppress console.error during tests
 beforeAll(() => {
@@ -19,12 +20,12 @@ beforeAll(async () => {
   const email = `testuser${Date.now()}@boardtests.com`;
   const password = 'testpassword';
 
-  await request('http://auth:8000')
+  await request(authServiceUrl)
     .post('/api/v1/users/')
     .send({ email, password });
 
   // Login to get JWT
-  const loginRes = await request('http://auth:8000')
+  const loginRes = await request(authServiceUrl)
     .post('/api/v1/token')
     .type('form')
     .send({ username: email, password });


### PR DESCRIPTION
## Overview
Implemented a comprehensive GitHub Actions CI/CD pipeline that automatically tests both microservices (Auth and Board) with proper database isolation and service orchestration.

## Key Features
Multi-Service Testing Pipeline:

- Sets up isolated PostgreSQL databases for each service (auth-postgres on port 5433, board-postgres on port 5432)
- Orchestrates testing of Python-based Auth service and Node.js-based Board service
- Implements proper service dependency management with health checks

## Database Management:

- Configures separate test databases (test_authdb and test_boarddb) to prevent cross-service contamination
- Runs database migrations for both services before testing
- Uses environment-specific database URLs for CI compatibility

## Service Orchestration:
- Tests Auth service in isolation first
- Starts Auth service in background for Board service integration tests
- Implements service readiness checks with timeout handling
- Seeds Auth service with required test data (guest user)

## Test Environment Configuration:
Configures all necessary environment variables for both services
Sets up proper JWT secrets and authentication tokens
Handles service-to-service communication via AUTH_SERVICE_URL

## Code Changes:
- Updated Board service tests to use environment variables for auth service URL (`process.env.AUTH_SERVICE_URL || http://auth:8000`)
- Maintains compatibility with both Docker Compose (container names) and CI environments (localhost)

## Technical Implementation
- Triggers: Runs on pushes to main, develop, and feature branches, plus pull requests
- Runtime: Ubuntu latest with Node.js 20 and Python 3.11
- Dependencies: Poetry for Python packages, npm for Node.js packages
- Database: PostgreSQL 15 with health checks and proper connection handling
- Testing: Pytest for Auth service, Jest for Board service with `--runInBand` flag for sequential execution